### PR TITLE
Notifications are now their own windows that appear to the right

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Styles = struct {
     .file_information: Style
     .error_bar: Style,
     .info_bar: Style,
+    .notification_box: Style,
 }
 
 Style = struct {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zfe",
-    .version = "0.5.2",
+    .version = "0.6.0",
     .minimum_zig_version = "0.13.0",
 
     .dependencies = .{

--- a/src/app.zig
+++ b/src/app.zig
@@ -783,7 +783,7 @@ fn draw_info(self: *App, win: vaxis.Window) !void {
             self.text_input.clearAndFree();
         }
 
-        notification_win.fill(.{ .style = config.styles.notifications_box });
+        notification_win.fill(.{ .style = config.styles.notification_box });
         _ = notification_win.printSegment(.{
             .text = self.notification.slice(),
             .style = switch (self.notification.style) {

--- a/src/config.zig
+++ b/src/config.zig
@@ -50,6 +50,9 @@ const Styles = struct {
         .bg = .{ .rgb = .{ 45, 45, 45 } },
         .bold = true,
     },
+    notifications_box: vaxis.Style = vaxis.Style{
+        .bg = .{ .rgb = .{ 45, 45, 45 } },
+    },
     list_item: vaxis.Style = vaxis.Style{},
     file_name: vaxis.Style = vaxis.Style{},
     file_information: vaxis.Style = vaxis.Style{

--- a/src/config.zig
+++ b/src/config.zig
@@ -50,7 +50,7 @@ const Styles = struct {
         .bg = .{ .rgb = .{ 45, 45, 45 } },
         .bold = true,
     },
-    notifications_box: vaxis.Style = vaxis.Style{
+    notification_box: vaxis.Style = vaxis.Style{
         .bg = .{ .rgb = .{ 45, 45, 45 } },
     },
     list_item: vaxis.Style = vaxis.Style{},

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -2,17 +2,21 @@ const std = @import("std");
 
 const Self = @This();
 
+// Seconds.
+pub const notification_timeout = 3;
+
 const Style = enum {
     err,
     info,
 };
 
+/// Simplified construct
 const Error = enum {
     PermissionDenied,
     UnknownError,
     UnableToUndo,
     UnableToOpenFile,
-    UnableToDeleteItem,
+    UnableToDelete,
     UnableToDeleteAcrossMountPoints,
     UnsupportedImageFormat,
     EditorNotSet,
@@ -21,10 +25,22 @@ const Error = enum {
     IncorrectPath,
 };
 
+const Info = enum {
+    CreatedFile,
+    CreatedFolder,
+    Deleted,
+    Renamed,
+    RestoredDelete,
+    RestoredRename,
+    EmptyUndo,
+    ChangedDir,
+};
+
 len: usize = 0,
 buf: [1024]u8 = undefined,
 style: Style = Style.info,
 fbs: std.io.FixedBufferStream([]u8) = undefined,
+timer: i64 = 0,
 
 pub fn init(self: *Self) void {
     self.fbs = std.io.fixedBufferStream(&self.buf);
@@ -33,6 +49,7 @@ pub fn init(self: *Self) void {
 pub fn write(self: *Self, text: []const u8, style: Style) !void {
     self.fbs.reset();
     self.len = try self.fbs.write(text);
+    self.timer = std.time.timestamp();
 
     self.style = style;
 }
@@ -42,7 +59,7 @@ pub fn write_err(self: *Self, err: Error) !void {
         .PermissionDenied => self.write("Permission denied.", .err),
         .UnknownError => self.write("An unknown error occurred.", .err),
         .UnableToOpenFile => self.write("Unable to open file.", .err),
-        .UnableToDeleteItem => self.write("Unable to delete item.", .err),
+        .UnableToDelete => self.write("Unable to delete item.", .err),
         .UnableToDeleteAcrossMountPoints => self.write("Unable to move item to /tmp. Failed to delete.", .err),
         .UnableToUndo => self.write("Unable to undo previous action.", .err),
         .ItemAlreadyExists => self.write("Item already exists.", .err),
@@ -50,6 +67,19 @@ pub fn write_err(self: *Self, err: Error) !void {
         .IncorrectPath => self.write("Unable to find path.", .err),
         .EditorNotSet => self.write("$EDITOR is not set.", .err),
         .UnsupportedImageFormat => self.write("Unsupported image format.", .err),
+    };
+}
+
+pub fn write_info(self: *Self, info: Info) !void {
+    try switch (info) {
+        .CreatedFile => self.write("Successfully created file.", .info),
+        .CreatedFolder => self.write("Successfully created folder.", .info),
+        .Deleted => self.write("Successfully deleted item.", .info),
+        .Renamed => self.write("Successfully renamed item.", .info),
+        .RestoredDelete => self.write("Successfully restored deleted item.", .info),
+        .RestoredRename => self.write("Successfully restored renamed item.", .info),
+        .EmptyUndo => self.write("Nothing to undo.", .info),
+        .ChangedDir => self.write("Successfully changed directory.", .info),
     };
 }
 


### PR DESCRIPTION
- feat: notifications are now their own windows that appear to the right 
  of the screen. they disappear after 3 seconds but note that renders
  only occur after an action has been polled. this means that if you
  wait for 3 seconds without an action, the notification wont disappear
  until an action occurs.
- refactor: added `write_info` function with associated `Info` enum.
- fix: fixed bug where attempting to delete, rename, or move within an empty directory would cause a crash.
- refactor: added info notifications on actions such as renaming, deleting, changing dir, etc.
- config: added `notification_box` colour setting to config.
- docs: updated docs to reflect new `notification_box` style option.

![image](https://github.com/user-attachments/assets/ab0b56fd-99f8-45a7-b08b-d8df33c9d49b)
figure: notification box