### PR TITLE
Fix notification segfaults

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zfe",
-    .version = "0.6.1",
+    .version = "0.6.2",
     .minimum_zig_version = "0.13.0",
 
     .dependencies = .{

--- a/src/app.zig
+++ b/src/app.zig
@@ -781,6 +781,11 @@ fn draw_user_input(self: *App, win: vaxis.Window) !void {
 
 fn draw_notification(self: *App, win: vaxis.Window) !void {
     if (self.notification.len > 0) {
+        if (std.time.timestamp() - self.notification.timer > Notification.notification_timeout) {
+            self.notification.reset();
+            return;
+        }
+
         const notification_width_padding = 4;
         const notification_height_padding = 3;
         const notification_screen_pos_padding = 10;
@@ -810,9 +815,5 @@ fn draw_notification(self: *App, win: vaxis.Window) !void {
                 .err => config.styles.error_bar,
             },
         }, .{ .wrap = .word });
-
-        if (std.time.timestamp() - self.notification.timer > Notification.notification_timeout) {
-            self.notification.reset();
-        }
     }
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -763,10 +763,6 @@ fn draw_user_input(self: *App, win: vaxis.Window) !void {
 
     switch (self.state) {
         .fuzzy, .new_file, .new_dir, .rename, .change_dir => {
-            // TODO: Investigate why removing this causes a segfault when
-            // entering user input while a notification is being rendered.
-            self.notification.reset();
-
             self.text_input.draw(user_input_win);
         },
         .normal => {
@@ -802,10 +798,6 @@ fn draw_notification(self: *App, win: vaxis.Window) !void {
             .height = @intCast(notification_height),
             .border = .{ .where = .all },
         });
-
-        if (self.text_input.buf.realLength() > 0) {
-            self.text_input.clearAndFree();
-        }
 
         notification_win.fill(.{ .style = config.styles.notification_box });
         _ = notification_win.printSegment(.{

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -39,7 +39,7 @@ len: usize = 0,
 buf: [1024]u8 = undefined,
 style: Style = Style.info,
 fbs: std.io.FixedBufferStream([]u8) = undefined,
-/// How long until the notification dissappears in seconds.
+/// How long until the notification disappears in seconds.
 timer: i64 = 0,
 
 pub fn init(self: *Self) void {

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const Self = @This();
 
-// Seconds.
+/// Seconds.
 pub const notification_timeout = 3;
 
 const Style = enum {
@@ -10,7 +10,6 @@ const Style = enum {
     info,
 };
 
-/// Simplified construct
 const Error = enum {
     PermissionDenied,
     UnknownError,
@@ -40,6 +39,7 @@ len: usize = 0,
 buf: [1024]u8 = undefined,
 style: Style = Style.info,
 fbs: std.io.FixedBufferStream([]u8) = undefined,
+/// How long until the notification dissappears in seconds.
 timer: i64 = 0,
 
 pub fn init(self: *Self) void {


### PR DESCRIPTION
There was an issue where if there was a notification being rendered and the user attempted to enter input mode, zfe would segfault. This was internal and unable to be hit by a user.

I also fixed up some doc strings.

