### PR TITLE
feat: add command mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ appropriate version or build locally via `zig build -Doptimize=ReleaseSafe`.
 ## Key manual
 ```
 Normal mode:
-q / <CTRL-c>       :Exit.
-
+<CTRL-c>           :Exit.
 j / <Down>         :Go down.
 k / <Up>           :Go up.
 h / <Left> / -     :Go to the parent directory.
@@ -30,18 +29,23 @@ l / <Right>        :Open item or change directory.
 g                  :Go to the top.
 G                  :Go to the bottom.
 c                  :Change directory via path. Will enter input mode.
-
 R                  :Rename item. Will enter input mode.
 D                  :Delete item.
 u                  :Undo delete/rename.
-
 d                  :Create directory. Will enter input mode.
 %                  :Create file. Will enter input mode.
 /                  :Fuzzy search directory. Will enter input mode.
+:                  :Allows for zfe commands to be entered. Please refer to the 
+                    "Command mode" section for available commands. Will enter 
+                    input mode.
 
 Input mode:
 <Esc>              :Cancel input.
-<Enter>            :Confirm input.
+<CR>               :Confirm input.
+
+Command mode:
+:q                 :Exit.
+:config            :Navigate to config directory if it exists.
 ```
 
 
@@ -65,15 +69,19 @@ Config = struct {
     .styles: Styles,
 }
 
+NotificationStyles = struct {
+    box: vaxis.Style,
+    err: vaxis.Style,
+    warn: vaxis.Style,
+    info: vaxis.Style,
+};
+
 Styles = struct {
     .selected_list_item: Style,
     .list_item: Style,
     .file_name: Style,
     .file_information: Style
-    .error_bar: Style,
-    .info_bar: Style,
-    .warning_bar: Style,
-    .notification_box: Style,
+    .notification: NotificationStyles,
     .git_branch: Style,
 }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zfe",
-    .version = "0.7.1",
+    .version = "0.8.0",
     .minimum_zig_version = "0.13.0",
 
     .dependencies = .{

--- a/example-config.json
+++ b/example-config.json
@@ -10,13 +10,17 @@
             },
             "bold": true
         },
-        "file_information": {
-            "fg": {
-                "rgb": [0, 0, 0]
-            },
-            "bg": {
-                "rgb": [255, 255, 255]
+        "notification": {
+            "info": {
+                "fg": {
+                    "rgb": [127, 255, 0]
+                }
             }
+        },
+        "git_branch": {
+            "fg": {
+                "rgb": [127, 255, 0]
+            }        
         }
     }
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -19,6 +19,7 @@ pub const State = enum {
     new_file,
     change_dir,
     rename,
+    command,
 };
 
 const ActionPaths = struct {
@@ -122,7 +123,7 @@ pub fn run(self: *App) !void {
                 .normal => {
                     try EventHandlers.handleNormalEvent(self, event, &loop);
                 },
-                .fuzzy, .new_file, .new_dir, .rename, .change_dir => {
+                .fuzzy, .new_file, .new_dir, .rename, .change_dir, .command => {
                     try EventHandlers.handleInputEvent(self, event);
                 },
             }

--- a/src/config.zig
+++ b/src/config.zig
@@ -13,6 +13,9 @@ const Config = struct {
     preview_file: bool = true,
     styles: Styles,
 
+    config_path_buf: [std.fs.max_path_bytes]u8 = undefined,
+    config_path: ?[]u8 = null,
+
     pub fn parse(self: *Config, alloc: std.mem.Allocator) !ParseRes {
         var deprecated = false;
         var config_location: struct {
@@ -68,38 +71,58 @@ const Config = struct {
         defer parsed_config.deinit();
 
         self.* = parsed_config.value;
+        self.config_path = config_location.home_dir.realpath(
+            config_location.path,
+            &self.config_path_buf,
+        ) catch null;
         return .{ .deprecated = deprecated };
     }
 };
 
+const Colours = struct {
+    const RGB = [3]u8;
+    const red: RGB = .{ 227, 23, 10 };
+    const orange: RGB = .{ 251, 139, 36 };
+    const blue: RGB = .{ 82, 209, 220 };
+    const grey: RGB = .{ 39, 39, 39 };
+    const black: RGB = .{ 0, 0, 0 };
+    const snow_white: RGB = .{ 254, 252, 253 };
+};
+
+const NotificationStyles = struct {
+    box: vaxis.Style = vaxis.Style{
+        .bg = .{ .rgb = Colours.grey },
+    },
+    err: vaxis.Style = vaxis.Style{
+        .fg = .{ .rgb = Colours.red },
+        .bg = .{ .rgb = Colours.grey },
+    },
+    warn: vaxis.Style = vaxis.Style{
+        .fg = .{ .rgb = Colours.orange },
+        .bg = .{ .rgb = Colours.grey },
+    },
+    info: vaxis.Style = vaxis.Style{
+        .fg = .{ .rgb = Colours.blue },
+        .bg = .{ .rgb = Colours.grey },
+    },
+};
+
 const Styles = struct {
     selected_list_item: vaxis.Style = vaxis.Style{
-        .bg = .{ .rgb = .{ 39, 39, 39 } },
+        .bg = .{ .rgb = Colours.grey },
         .bold = true,
     },
-    notification_box: vaxis.Style = vaxis.Style{
-        .bg = .{ .rgb = .{ 39, 39, 39 } },
-    },
+    notification: NotificationStyles = NotificationStyles{},
+    text_input: vaxis.Style = vaxis.Style{},
+    text_input_err: vaxis.Style = vaxis.Style{ .bg = .{ .rgb = Colours.red } },
     list_item: vaxis.Style = vaxis.Style{},
     file_name: vaxis.Style = vaxis.Style{},
     file_information: vaxis.Style = vaxis.Style{
-        .fg = .{ .rgb = .{ 0, 0, 0 } },
-        .bg = .{ .rgb = .{ 254, 252, 253 } },
-    },
-    error_bar: vaxis.Style = vaxis.Style{
-        .fg = .{ .rgb = .{ 227, 23, 10 } },
-        .bg = .{ .rgb = .{ 39, 39, 39 } },
-    },
-    warning_bar: vaxis.Style = vaxis.Style{
-        .fg = .{ .rgb = .{ 251, 139, 36 } },
-        .bg = .{ .rgb = .{ 39, 39, 39 } },
-    },
-    info_bar: vaxis.Style = vaxis.Style{
-        .fg = .{ .rgb = .{ 82, 209, 220 } },
-        .bg = .{ .rgb = .{ 39, 39, 39 } },
+        .fg = .{ .rgb = Colours.black },
+        .bg = .{ .rgb = Colours.snow_white },
     },
     git_branch: vaxis.Style = vaxis.Style{
-        .fg = .{ .rgb = .{ 82, 209, 220 } },
+        .fg = .{ .rgb = Colours.blue },
     },
 };
 


### PR DESCRIPTION
feat: added command mode.
command mode is a way for users to enter zfe commands. This work will
help deal with the future rework of the deletion feature.
currently supported commands:
    - :q to quit zfe
    - :config to navigate to the config dir if found
    
chore: updated readme.
breaking: reworked the notifcation stylings. notification
stylings are now under the `notification` namespace within the config
file.

