### PR TITLE
refactor: deletes are now sent to `<config>/trash` instead of `/tmp`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ![zfe preview](./assets/preview.png)
 
-**zfe** is a small unix tui file explorer designed to be simple and fast.
+**zfe** is a small unix tui file explorer with vim-like bindings designed to 
+be simple and fast.
 
 - [Installation](#installation)
 - [Integrations](#integrations)
@@ -46,6 +47,8 @@ Input mode:
 Command mode:
 :q                 :Exit.
 :config            :Navigate to config directory if it exists.
+:trash             :Navigate to trash directory if it exists.
+:empty_trash       :Empty trash if it exists.
 ```
 
 
@@ -66,6 +69,7 @@ Config = struct {
     .sort_dirs: bool,
     .show_images: bool,
     .preview_file: bool,
+    .empty_trash_on_exit: bool,
     .styles: Styles,
 }
 

--- a/src/app.zig
+++ b/src/app.zig
@@ -123,7 +123,7 @@ pub fn run(self: *App) !void {
                 .normal => {
                     try EventHandlers.handleNormalEvent(self, event, &loop);
                 },
-                .fuzzy, .new_file, .new_dir, .rename, .change_dir, .command => {
+                else => {
                     try EventHandlers.handleInputEvent(self, event);
                 },
             }
@@ -134,5 +134,13 @@ pub fn run(self: *App) !void {
         var buffered = self.tty.bufferedWriter();
         try self.vx.render(buffered.writer().any());
         try buffered.flush();
+    }
+
+    if (config.empty_trash_on_exit) {
+        if (try config.trashDir()) |dir| {
+            var trash_dir = dir;
+            defer trash_dir.close();
+            _ = try environment.deleteContents(trash_dir);
+        }
     }
 }

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -1,0 +1,67 @@
+const App = @import("app.zig");
+const environment = @import("environment.zig");
+const _config = &@import("./config.zig").config;
+
+///Navigate the user to the config dir.
+pub fn config(app: *App) !void {
+    const dir = dir: {
+        notfound: {
+            break :dir (_config.configDir() catch break :notfound) orelse break :notfound;
+        }
+        try app.notification.writeErr(.ConfigPathNotFound);
+        return;
+    };
+    app.directories.clearEntries();
+    app.directories.dir.close();
+    app.directories.dir = dir;
+    app.directories.populateEntries("") catch |err| {
+        switch (err) {
+            error.AccessDenied => try app.notification.writeErr(.PermissionDenied),
+            else => try app.notification.writeErr(.UnknownError),
+        }
+    };
+}
+
+///Navigate the user to the trash dir.
+pub fn trash(app: *App) !void {
+    const dir = dir: {
+        notfound: {
+            break :dir (_config.trashDir() catch break :notfound) orelse break :notfound;
+        }
+        try app.notification.writeErr(.ConfigPathNotFound);
+        return;
+    };
+    app.directories.clearEntries();
+    app.directories.dir.close();
+    app.directories.dir = dir;
+    app.directories.populateEntries("") catch |err| {
+        switch (err) {
+            error.AccessDenied => try app.notification.writeErr(.PermissionDenied),
+            else => try app.notification.writeErr(.UnknownError),
+        }
+    };
+}
+
+///Empty the trash.
+pub fn emptyTrash(app: *App) !void {
+    const dir = dir: {
+        notfound: {
+            break :dir (_config.trashDir() catch break :notfound) orelse break :notfound;
+        }
+        try app.notification.writeErr(.ConfigPathNotFound);
+        return;
+    };
+
+    var trash_dir = dir;
+    defer trash_dir.close();
+    const failed = try environment.deleteContents(trash_dir);
+    if (failed > 0) try app.notification.writeErr(.FailedToDeleteSomeItems);
+
+    app.directories.clearEntries();
+    app.directories.populateEntries("") catch |err| {
+        switch (err) {
+            error.AccessDenied => try app.notification.writeErr(.PermissionDenied),
+            else => try app.notification.writeErr(.UnknownError),
+        }
+    };
+}

--- a/src/environment.zig
+++ b/src/environment.zig
@@ -67,3 +67,15 @@ pub fn dirExists(dir: std.fs.Dir, path: []const u8) bool {
     };
     return result;
 }
+
+///Returns the amount of files failed to be delete.
+pub fn deleteContents(dir: std.fs.Dir) !usize {
+    var failed: usize = 0;
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        dir.deleteTree(entry.name) catch {
+            failed += 1;
+        };
+    }
+    return failed;
+}

--- a/src/event_handlers.zig
+++ b/src/event_handlers.zig
@@ -129,7 +129,7 @@ pub fn handleNormalEvent(
                     var old_path_buf: [std.fs.max_path_bytes]u8 = undefined;
                     const old_path = try app.alloc.dupe(u8, try app.directories.dir.realpath(entry.name, &old_path_buf));
 
-                    const trash_dir = dir: {
+                    var trash_dir = dir: {
                         notfound: {
                             break :dir (config.trashDir() catch break :notfound) orelse break :notfound;
                         }

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -17,6 +17,7 @@ const Error = enum {
     UnableToUndo,
     UnableToOpenFile,
     UnableToDelete,
+    FailedToDeleteSomeItems,
     UnableToDeleteAcrossMountPoints,
     UnsupportedImageFormat,
     EditorNotSet,
@@ -25,6 +26,8 @@ const Error = enum {
     IncorrectPath,
     ConfigSyntaxError,
     ConfigUnknownError,
+    ConfigPathNotFound,
+    CannotDeleteTrashDir,
 };
 
 const Info = enum {
@@ -64,6 +67,7 @@ pub fn writeErr(self: *Self, err: Error) !void {
         .UnknownError => self.write("An unknown error occurred.", .err),
         .UnableToOpenFile => self.write("Unable to open file.", .err),
         .UnableToDelete => self.write("Unable to delete item.", .err),
+        .FailedToDeleteSomeItems => self.write("Failed to delete some items..", .err),
         .UnableToDeleteAcrossMountPoints => self.write("Unable to move item to /tmp. Failed to delete.", .err),
         .UnableToUndo => self.write("Unable to undo previous action.", .err),
         .ItemAlreadyExists => self.write("Item already exists.", .err),
@@ -73,6 +77,8 @@ pub fn writeErr(self: *Self, err: Error) !void {
         .UnsupportedImageFormat => self.write("Unsupported image format.", .err),
         .ConfigSyntaxError => self.write("Could not read config due to a syntax error.", .err),
         .ConfigUnknownError => self.write("Could not read config due to an unknown error.", .err),
+        .ConfigPathNotFound => self.write("Could not read config due to unset env variables. Please set either $HOME or $XDG_CONFIG_HOME.", .err),
+        .CannotDeleteTrashDir => self.write("Cannot delete trash directory.", .err),
     };
 }
 


### PR DESCRIPTION
previously, deletes were sent to `/tmp`. this made it convenient for cleanup however caused issues on certain distros. this was because the `/tmp` dir was on a separate mount point and therefore the file was unable to be moved there.

added two new commands, `trash` and `empty_trash`.