### PR TITLE
fix: input cursor unable to move left/right

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -207,7 +207,10 @@ pub fn deinit(self: *App) void {
     self.images.cache.deinit();
 }
 
-pub fn inputToSlice(self: *App) []const u8 {
+/// Reads the current text input without consuming it.
+/// The returned slice is valid until the next call to readInput() or until
+/// the text_input buffer is modified.
+pub fn readInput(self: *App) []const u8 {
     const first = self.text_input.buf.firstHalf();
     const second = self.text_input.buf.secondHalf();
     var dest_idx: usize = 0;

--- a/src/directories.zig
+++ b/src/directories.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const List = @import("./list.zig").List;
 const CircStack = @import("./circ_stack.zig").CircularStack;
 const config = &@import("./config.zig").config;
-const vaxis = @import("vaxis");
 const fuzzig = @import("fuzzig");
 
 const history_len: usize = 100;

--- a/src/drawer.zig
+++ b/src/drawer.zig
@@ -62,7 +62,7 @@ pub fn draw(self: *Drawer, app: *App) error{ OutOfMemory, NoSpaceLeft }!void {
         try self.drawFilePreview(app, win, file_name_bar);
     }
 
-    const input = app.inputToSlice();
+    const input = app.readInput();
     drawUserInput(app.state, &app.text_input, input, win);
 
     // Notification should be drawn last.

--- a/src/event_handlers.zig
+++ b/src/event_handlers.zig
@@ -221,8 +221,6 @@ pub fn handleInputEvent(app: *App, event: App.Event) !void {
                     if (app.state != .help_menu) app.state = .normal;
                     app.directories.entries.selected = selected;
                 },
-                Key.left => app.text_input.cursorLeft(),
-                Key.right => app.text_input.cursorRight(),
                 Key.up => {
                     if (app.state == .command) {
                         if (app.command_history.previous()) |command| {


### PR DESCRIPTION
- **fix: modify inputToSlice to no longer manipulate the internal textinput buffer**
- **refactor: rename `inputToSlice` -> `readInput` refactor: use `toOwnedSlice` when appropriate**
